### PR TITLE
varnlevels needs to be integer (throws error when using matrix X)

### DIFF
--- a/R/bigrfc.R
+++ b/R/bigrfc.R
@@ -99,7 +99,7 @@ bigrfc <- function(x,
                 "specified. Number of levels cannot be inferred so all ",
                 "variables will be treated as numeric.")
         factorvars <- logical(length(varselect))
-        varnlevels <- numeric(length(varselect))
+        varnlevels <- integer(length(varselect))
     } else {
         if (!is.integer(varnlevels)) {
             stop("Argument varnlevels must be an integer vector.")


### PR DESCRIPTION
Also, what's your opinion about the warning message:

"x is not a data.frame and argument varnlevels is not specified. Number of levels cannot be inferred so all variables will be treated as numeric"?

I feel like when folks supply a matrix X rather than a data frame, they probably know what they're trying to do and don't need the reminder.