### PR TITLE
New way to get CType for big.matrix

### DIFF
--- a/R/grow.R
+++ b/R/grow.R
@@ -219,7 +219,7 @@ setMethod("grow", signature(forest="bigcforest"), function(
         
         if (trace >= 2L) message("Tree ", treenum, ": Growing tree.")
         
-        xtype <- as.integer(.Call("CGetType", x@address, PACKAGE="bigmemory"))
+        xtype <- as.integer(bigmemory:::getCType(x))
         tree <- .Call("growtreeC", x@address, xtype, a@address, a.out@address,
                       forest, insamp, inweight, treenum, trace)
         

--- a/R/predict.R
+++ b/R/predict.R
@@ -93,7 +93,7 @@ setMethod("predict", signature(object="bigcforest"), function(
     }
     
     ntest <- as.integer(nrow(x))
-    xtype <- as.integer(.Call("CGetType", x@address, PACKAGE="bigmemory"))
+    xtype <- as.integer(bigmemory:::getCType(x))
     ynclass <- length(levels(forest@y))
     
     # fast fix on the test data

--- a/R/varimp.R
+++ b/R/varimp.R
@@ -95,7 +95,7 @@ setMethod("varimp", signature(forest="bigcforest"),  function(
     
     nvar <- length(forest@varselect)
     ntest <- as.integer(nrow(x));
-    xtype <- as.integer(.Call("CGetType", x@address, PACKAGE="bigmemory"))
+    xtype <- as.integer(bigmemory:::getCType(x))
     
     importance <- numeric(nvar)
     importance.sq <- numeric(nvar)


### PR DESCRIPTION
The new version of bigmemory has a private function (getCType) that needs to be called instead of calling the C function directly. These changes use the new interface that will soon be on CRAN.